### PR TITLE
Include <iframe> contents in bookmarklets' element selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.2.3 &mdash; 2025-04-06
+
+* Expanded the bookmarklets' search to include iframe elements where possible.
+
 ## v0.2.2 &mdash; 2016-04-01
 
 * Added a ```String.prototype.includes``` method polyfill (from Mozilla MDN) to

--- a/tests/acc-desc.html
+++ b/tests/acc-desc.html
@@ -1,5 +1,8 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>acc-desc.html</title>
 </head>
 

--- a/tests/embedded-controls.html
+++ b/tests/embedded-controls.html
@@ -1,5 +1,8 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>embedded-controls.html</title>
   <style>
     label::before {

--- a/tests/header-footer.html
+++ b/tests/header-footer.html
@@ -1,5 +1,8 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>header-footer.html</title>
 </head>
 

--- a/tests/iframes.html
+++ b/tests/iframes.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta name="description" content="iframes test">
+	<title>iframes.html</title>
+
+	<style>
+		iframe {
+			display: block;
+			width: 100%;
+			max-width: 1100px;
+			margin-inline: auto;
+			height: 500px;
+		}
+	</style>
+</head>
+<body>
+	<header>
+		<h1>iframes Test</h1>
+	</header>
+	<main>
+		<h2>srcdoc frame</h2>
+		<iframe title="header-footer" srcdoc="<h1>I'm in an iframe</h1><main><h2>Me too!</h2><label>write something<input type='text'></label></main>"></iframe>
+	</main>
+</body>
+</html>

--- a/tests/roles.html
+++ b/tests/roles.html
@@ -1,5 +1,8 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>roles.html</title>
 </head>
 

--- a/utils/overlay.js
+++ b/utils/overlay.js
@@ -11,12 +11,22 @@ var zIndex = 100000;
 *   createOverlay: Create overlay div with size and position based on the
 *   boundingRect properties of its corresponding target element.
 */
-function createOverlay (tgt, rect, cname) {
+/**
+ * 
+ * @param {Element} tgt Target element
+ * @param {DOMRect} rect Target element bounding rectangle
+ * @param {string} cname CSS class
+ * @param {Document} doc Owning document
+ * @returns Overlay node
+ */
+function createOverlay (tgt, rect, cname, doc) {
+  doc = doc || document;
+
   let scrollOffsets = getScrollOffsets();
   const MINWIDTH  = 68;
   const MINHEIGHT = 27;
 
-  let node = document.createElement("div");
+  let node = doc.createElement("div");
   node.setAttribute("class", [cname, 'oaa-element-overlay'].join(' '));
   node.startLeft = (rect.left + scrollOffsets.x) + "px";
   node.startTop  = (rect.top  + scrollOffsets.y) + "px";
@@ -28,7 +38,7 @@ function createOverlay (tgt, rect, cname) {
   node.style.borderColor = tgt.color;
   node.style.zIndex = zIndex;
 
-  let label = document.createElement("div");
+  let label = doc.createElement("div");
   label.setAttribute("class", 'oaa-overlay-label');
   label.style.backgroundColor = tgt.color;
   label.innerHTML = tgt.label;


### PR DESCRIPTION
This pull request expands the bookmarklets' search for elements with accessibility features to include `<iframe>` contents where possible.

This would increase the bookmarklets' utility for complex web apps which use same-origin `<iframe>` elements frequently.